### PR TITLE
Fixes destination file paths when copying a pattern in multiple sub directories

### DIFF
--- a/zip_maker.rb
+++ b/zip_maker.rb
@@ -224,8 +224,8 @@ config.each do |cfg_entry|
             if !exclude
               dst_file = src_file
               if element_present?(file_entry, 'dst_path')
-                split_file = dst_file.split('/')[-1]
-                dst_file = File.join(file_entry['dst_path'], split_file)
+                base_dst_file = File.basename(dst_file)
+                dst_file = File.join(file_entry['dst_path'], base_dst_file)
               end
               
               if File.directory?(src_file)

--- a/zip_maker.rb
+++ b/zip_maker.rb
@@ -224,9 +224,8 @@ config.each do |cfg_entry|
             if !exclude
               dst_file = src_file
               if element_present?(file_entry, 'dst_path')
-                split_file = dst_file.split('/')
-                dst_file = split_file[1..split_file.length].join('/')
-                dst_file = File.join(file_entry['dst_path'], dst_file)
+                split_file = dst_file.split('/')[-1]
+                dst_file = File.join(file_entry['dst_path'], split_file)
               end
               
               if File.directory?(src_file)


### PR DESCRIPTION
This fix resolves the situation below. In this situation I want all files file ending in `.tf` from `directory_a/directory_b/` to be copied to the root of the zip file.

```json
[
   {
      "action":"create_zip",
      "file_name":"example.zip",
      "files":[
         {
            "src_pattern":"directory_a/directory_b/*.tf",
            "dst_path":"."
         }
      ]
   },
   {
      "action":"upload_file",
      "file_name":"example.zip"
   }
]
```

Currently this doesn't work and instead all the file end up as `directory_b/*.tf` instead. 

This fix gets the split file name and adds any destination path to the beginning of it instead of reconstructing the path again, which appears to be what it was doing originally.
